### PR TITLE
Lock version of node-neat to prevent incompatible versions of node-bourbon

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jade": "^1.9.0",
     "lodash": "^2.4.1",
     "node-bourbon": "^1.2.3",
-    "node-neat": "^1.4.2"
+    "node-neat": "1.4.2"
   },
   "devDependencies": {
     "del": "^1.1.1",


### PR DESCRIPTION
This prevents the following issue from happening, when building respoke.js docs on node v4.2.3:

```
Running "sass:docs" (sass) task
>> Incompatible units: '' and 'em'.
>> 
>> Backtrace:
>>  ../style/node_modules/node-neat/node_modules/node-bourbon/node_modules/bourbon/app/assets/stylesheets/functions/_modular-scale.scss:40, in function `modular-scale`
>>  docs.scss:47
>>   Line 40  Column 18  ../style/node_modules/node-neat/node_modules/node-bourbon/node_modules/bourbon/app/assets/stylesheets/functions/_modular-scale.scss
Warning:  Use --force to continue.

Aborted due to warnings.

npm ERR! Darwin 15.2.0
npm ERR! argv "/Users/jeffparrish/.nvm/versions/node/v4.2.3/bin/node" "/Users/jeffparrish/.nvm/versions/node/v4.2.3/bin/npm" "run" "docs"
npm ERR! node v4.2.3
npm ERR! npm  v2.14.7
npm ERR! code ELIFECYCLE
npm ERR! respoke@1.55.1 docs: `grunt docs`
npm ERR! Exit status 6
npm ERR! 
npm ERR! Failed at the respoke@1.55.1 docs script 'grunt docs'.
npm ERR! This is most likely a problem with the respoke package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     grunt docs
npm ERR! You can get their info via:
npm ERR!     npm owner ls respoke
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/jeffparrish/transporter/npm-debug.log
```
